### PR TITLE
Temporarily removing localhost endpoint for live

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,7 +16,14 @@ export default function Home({ hero }) {
 }
 
 export async function getStaticProps() {
-    let { data } = await Axios.get('http://localhost:3000/api/cms');
+    // let { data } = await Axios.get('http://localhost:3000/api/cms');
+
+    let data = {
+        header: 'Your Custom Star Map',
+        content: 'Create a 18"x24" star map that shows the stars exactly as they were on a specific date and location with a personalized message!',
+        cta: 'Create Your Star Map',
+        src: '/images/hero.png'
+    }
 
     return {
         props: {


### PR DESCRIPTION
This will be a temporary swap until a live link can be used to pull the cms data